### PR TITLE
Fixes-148-move bgImages into src/lib/themes.js as a shared export

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -1,13 +1,11 @@
 import { makeLog } from "../lib/utils";
-import { normalizeTheme, colorToCSS } from "../lib/themes";
+import { normalizeTheme, colorToCSS, bgImages } from "../lib/themes";
 
 // Blank 1x1 PNG from http://png-pixel.com/
 const BLANK_IMAGE =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 
 const log = makeLog("background");
-
-const bgImages = require.context("../images/patterns/", false, /bg-.*\.svg/);
 
 const siteUrl = process.env.SITE_URL;
 

--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -51,6 +51,8 @@ export const normalizeTheme = (data = {}) => {
   return theme;
 };
 
+export const bgImages = require.context("../images/patterns/", false, /bg-.*\.svg/);
+
 export const presetThemes = presetThemesContext
   .keys()
   .map((filename, idx) => ({
@@ -59,3 +61,5 @@ export const presetThemes = presetThemesContext
     ...normalizeTheme(presetThemesContext(filename))
   }))
   .sort(({ filename: a }, { filename: b }) => a.localeCompare(b));
+
+

--- a/src/web/lib/components/BrowserPreview/index.js
+++ b/src/web/lib/components/BrowserPreview/index.js
@@ -2,11 +2,10 @@ import React from "react";
 import ReactSVG from "react-svg";
 import classnames from "classnames";
 
-import { colorToCSS } from "../../../../lib/themes";
+import { colorToCSS, bgImages } from "../../../../lib/themes";
 
 import "./index.scss";
 
-const bgImages = require.context("../../../../images/patterns/", false, /bg-.*\.svg/);
 const buttonImages = require.context(
   "../../../../images/",
   false,

--- a/src/web/lib/components/ThemeBackgroundPicker/index.js
+++ b/src/web/lib/components/ThemeBackgroundPicker/index.js
@@ -2,12 +2,9 @@ import React from "react";
 import classnames from "classnames";
 import onClickOutside from "react-onclickoutside";
 
-import { colorToCSS } from "../../../../lib/themes";
+import { colorToCSS, bgImages } from "../../../../lib/themes";
 import Metrics from "../../../../lib/metrics";
-
 import "./index.scss";
-
-const bgImages = require.context("../../../../images/patterns/", false, /bg-.*\.svg/);
 
 const Background = ({
   src,


### PR DESCRIPTION
Fixes [#148](https://github.com/mozilla/Themer/issues/148)
Files changed in this PR-
1. `themes.js`
2. `background.js`
3. `BrowserPreview/index.js`
4. `ThemeBackgroundPicker/index.js`