### PR TITLE
Add check to see if Themer tab already exists before creating new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "name": "Themer",
     "permissions": [
       "theme",
-      "storage"
+      "storage",
+      "tabs"
     ],
     "browser_action": {
       "browser_style": true,

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -12,9 +12,18 @@ const bgImages = require.context("../images/patterns/", false, /bg-.*\.svg/);
 const siteUrl = process.env.SITE_URL;
 
 const init = () => {
-  browser.browserAction.onClicked.addListener(() =>
-    browser.tabs.create({ url: siteUrl })
-  );
+  browser.browserAction.onClicked.addListener(() => {
+    browser.tabs.query({ currentWindow: true })
+      .then(tabs => {
+        const themerTab = tabs.find(tab => {
+          return tab.title === "Firefox Themer";
+        });
+        if (themerTab)
+          browser.tabs.update(themerTab.id, { active: true });
+        else
+          browser.tabs.create({ url: siteUrl });
+      });
+  });
   browser.runtime.onConnect.addListener(port => {
     port.onMessage.addListener(messageListener(port));
     port.postMessage({ type: "hello" });

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -15,13 +15,12 @@ const init = () => {
   browser.browserAction.onClicked.addListener(() => {
     browser.tabs.query({ currentWindow: true })
       .then(tabs => {
-        const themerTab = tabs.find(tab => {
-          return tab.title === "Firefox Themer";
-        });
-        if (themerTab)
+        const themerTab = tabs.find(tab => tab.url.includes(siteUrl));
+        if (themerTab) {
           browser.tabs.update(themerTab.id, { active: true });
-        else
+        } else {
           browser.tabs.create({ url: siteUrl });
+        }
       });
   });
   browser.runtime.onConnect.addListener(port => {


### PR DESCRIPTION
Fixes #119. Currently, when the browserAction button is pressed, a new Themer generator tab is always created. As an enhancement, these changes check the current window's tabs for a Themer tab and if found, sets the Themer tab to be active / focused. If a Themer tab is not found, then one is created like the original implementation.

In order to query the window's tabs, the `tabs` permission had to be added.

**Demo:**
![themer_119](https://user-images.githubusercontent.com/16343560/37259405-041adbb8-2543-11e8-964f-7e2301026037.gif)
