### PR TITLE
Fixes-194-Odd gap in Saved themes, even w/ pagination

### DIFF
--- a/src/web/lib/components/SavedThemeSelector/index.js
+++ b/src/web/lib/components/SavedThemeSelector/index.js
@@ -23,7 +23,7 @@ export const SavedThemeSelector = ({
       previewClassName="saved-theme-preview"
       onClick={theme => setTheme({ theme })}
       onDelete={key => deleteTheme(key)}
-      perPage={8}
+      perPage={12}
       currentPage={savedThemesPage}
       setCurrentPage={setSavedThemesPage}
     />


### PR DESCRIPTION
Fixes [#194](https://github.com/mozilla/Themer/issues/194)
File changed in this PR-
1. `src/web/lib/components/SavedThemeSelector/index.js`