### PR TITLE
Fixes-191-The 'Hand' pointer is wrongly displayed when hovering the 'Color Picker' backgound area

### DIFF
--- a/src/web/lib/_picker.scss
+++ b/src/web/lib/_picker.scss
@@ -7,7 +7,6 @@
   background: linear-gradient(rgba(255, 255, 255, .9), var(--white));
   border-radius: 2px;
   box-shadow: 0 2px 0 rgba(0, 0, 0, .05), 0 0 10px rgba(0, 0, 0, .1);
-  cursor: pointer;
   display: flex;
   font-size: 16px;
   height: 56px;
@@ -104,6 +103,7 @@
 @mixin picker-swatch {
   border: 2px solid var(--grey-30);
   border-radius: 18px;
+  cursor: pointer;
   flex: 0 0 36px;
   height: 36px;
 }
@@ -111,6 +111,7 @@
 @mixin picker-text {
   padding-left: $grid * 2.5;
   user-select: none;
+  cursor: pointer;
 }
 
 @mixin picker-small {


### PR DESCRIPTION
Fixes [#191](https://github.com/mozilla/Themer/issues/191)

File changed in this PR-
1. `src/web/lib/_picker.scss`