### PR TITLE
Fixes-189-Wrong tooltip is displayed when the Hex, R, G and B text fileds from the 'Color Picker' panel are hovered

### DIFF
--- a/src/web/lib/components/ThemeColorsEditor/index.js
+++ b/src/web/lib/components/ThemeColorsEditor/index.js
@@ -69,10 +69,9 @@ class ThemeColorsEditor extends React.Component {
                 key={`dt-${idx}`}
                 className={classnames(name, "color", { selected: selectedColor === name })}
                 onClick={ev => this.handleClick(ev, name)}
-                title={colorLabels[name]}
               >
-                <span className="color__swatch"style={{ backgroundColor: colorToCSS(color) }} />
-                <span className="color__label">{colorLabels[name]}</span>
+                <span className="color__swatch" style={{ backgroundColor: colorToCSS(color) }} title={colorLabels[name]} />
+                <span className="color__label" title={colorLabels[name]} >{colorLabels[name]}</span>
                 <span className="color__picker">
                   <SketchPicker
                     color={{ h: color.h, s: color.s, l: color.l, a: color.a * 0.01 }}


### PR DESCRIPTION
Fixes [#189](https://github.com/mozilla/Themer/issues/189)

File changed in this PR-
1. `src/web/lib/components/ThemeColorsEditor/index.js`