### PR TITLE
Fixes-193-Wrong tooltip is displayed when the 'Themes Textures' are hovered

### DIFF
--- a/src/web/lib/components/ThemeBackgroundPicker/index.js
+++ b/src/web/lib/components/ThemeBackgroundPicker/index.js
@@ -74,16 +74,16 @@ class ThemeBackgroundPicker extends React.Component {
       <div
         className={classnames("theme-background-picker", { selected })}
         onClick={this.handleClick.bind(this)}
-        title="Theme Texture"
       >
         <span
           className="theme-background-picker__swatch"
+          title="Theme Texture"
           style={{
             backgroundColor: accentcolor,
             backgroundImage: backgroundSwatch
           }}
         />
-        <span className="theme-background-picker__text">Theme Texture</span>
+        <span className="theme-background-picker__text" title="Theme Texture">Theme Texture</span>
         <div className="theme-background-picker__backgrounds">
           <div className="theme-background-picker__backgrounds-inner">
             {bgImages.keys().map((src, backgroundId) => (


### PR DESCRIPTION
Fixes [#193](https://github.com/mozilla/Themer/issues/193)

File changed in this PR-
1.`src/web/lib/components/ThemeBackgroundPicker/index.js`